### PR TITLE
ML fixes; properly import @tailwind & use @apply; fix ./json import

### DIFF
--- a/src/block1/edit.js
+++ b/src/block1/edit.js
@@ -19,7 +19,7 @@ import { useBlockProps } from '@wordpress/block-editor';
  *
  * @see https://www.npmjs.com/package/@wordpress/scripts#using-css
  */
-import './editor.scss';
+import './editor.css';
 
 /**
  * The edit function describes the structure of your block in the context of the

--- a/src/block1/editor.css
+++ b/src/block1/editor.css
@@ -4,6 +4,11 @@
  * Replace them with your own styles or remove the file completely.
  */
 
+ @tailwind base;
+ @tailwind components;
+ @tailwind utilities;
+
 .wp-block-create-block-block1 {
-	border: 2px dotted #f00;
+	/* border: 2px dotted #f00; */
+    @apply border-2 border-green-300;
 }

--- a/src/block1/index.js
+++ b/src/block1/index.js
@@ -12,14 +12,16 @@ import { registerBlockType } from '@wordpress/blocks';
  *
  * @see https://www.npmjs.com/package/@wordpress/scripts#using-css
  */
-import './style.scss';
+// import './style.scss';
+// import './style.postcss';
+import './style.css';
 
 /**
  * Internal dependencies
  */
 import Edit from './edit';
 import save from './save';
-import json from './json';
+import json from './block.json';
 
 const { name } = json;
 

--- a/src/block1/index.js
+++ b/src/block1/index.js
@@ -12,7 +12,7 @@ import { registerBlockType } from '@wordpress/blocks';
  *
  * @see https://www.npmjs.com/package/@wordpress/scripts#using-css
  */
-// import './style.scss';
+// import './style.css';
 // import './style.postcss';
 import './style.css';
 

--- a/src/block1/style.css
+++ b/src/block1/style.css
@@ -5,10 +5,10 @@
  * Replace them with your own styles or remove the file completely.
  */
 
-@tailwind components;
-@tailwind utilities;
+ @tailwind base;
+ @tailwind components;
+ @tailwind utilities;
 
 .wp-block-create-block-block1 {
-	background-color: #21759b;
-	color: #fff;
+    @apply bg-purple-800 text-slate-400 border-2 border-green-400 rounded;
 }

--- a/src/block1/tailwind.config.js
+++ b/src/block1/tailwind.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-	content: ['./src/block1/*js'],
+	content: ['./src/block1/*js', './src/block1/*css'],
 	theme: {
 		extend: {},
 	},

--- a/src/block2/edit.js
+++ b/src/block2/edit.js
@@ -19,7 +19,7 @@ import { useBlockProps } from '@wordpress/block-editor';
  *
  * @see https://www.npmjs.com/package/@wordpress/scripts#using-css
  */
-import './editor.scss';
+import './editor.css';
 
 /**
  * The edit function describes the structure of your block in the context of the

--- a/src/block2/editor.css
+++ b/src/block2/editor.css
@@ -4,6 +4,11 @@
  * Replace them with your own styles or remove the file completely.
  */
 
+ @tailwind base;
+ @tailwind components;
+ @tailwind utilities;
+
 .wp-block-create-block-block2 {
-	border: 2px dotted #f00;
+	/* border: 2px dotted #f00; */
+	@apply border-2 border-dotted border-[#f00];
 }

--- a/src/block2/index.js
+++ b/src/block2/index.js
@@ -12,14 +12,14 @@ import { registerBlockType } from '@wordpress/blocks';
  *
  * @see https://www.npmjs.com/package/@wordpress/scripts#using-css
  */
-import './style.scss';
+import './style.css';
 
 /**
  * Internal dependencies
  */
 import Edit from './edit';
 import save from './save';
-import json from './json';
+import json from './block.json';
 
 const { name } = json;
 

--- a/src/block2/style.css
+++ b/src/block2/style.css
@@ -5,10 +5,12 @@
  * Replace them with your own styles or remove the file completely.
  */
 
-@tailwind components;
-@tailwind utilities;
+ @tailwind base;
+ @tailwind components;
+ @tailwind utilities;
 
 .wp-block-create-block-block2 {
-	background-color: #1dd85c;
-	color: #fff;
+	/* background-color: #1dd85c;
+	color: #fff; */
+	@apply bg-[#1dd85c] text-[#fff];
 }

--- a/src/block2/tailwind.config.js
+++ b/src/block2/tailwind.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-	content: ['./src/block2/*js'],
+	content: ['./src/block1/*js', './src/block1/*css'],
 	theme: {
 		extend: {},
 	},

--- a/src/block3/edit.js
+++ b/src/block3/edit.js
@@ -19,7 +19,7 @@ import { useBlockProps } from '@wordpress/block-editor';
  *
  * @see https://www.npmjs.com/package/@wordpress/scripts#using-css
  */
-import './editor.scss';
+import './editor.css';
 
 /**
  * The edit function describes the structure of your block in the context of the

--- a/src/block3/editor.css
+++ b/src/block3/editor.css
@@ -4,6 +4,11 @@
  * Replace them with your own styles or remove the file completely.
  */
 
+ @tailwind base;
+ @tailwind components;
+ @tailwind utilities;
+
 .wp-block-create-block-block3 {
-	border: 2px dotted #f00;
+	/* border: 2px dotted #f00; */
+	@apply border-2 border-dotted border-[#f00];
 }

--- a/src/block3/index.js
+++ b/src/block3/index.js
@@ -12,14 +12,14 @@ import { registerBlockType } from '@wordpress/blocks';
  *
  * @see https://www.npmjs.com/package/@wordpress/scripts#using-css
  */
-import './style.scss';
+import './style.css';
 
 /**
  * Internal dependencies
  */
 import Edit from './edit';
 import save from './save';
-import json from './json';
+import json from './block.json';
 
 const { name } = json;
 

--- a/src/block3/style.css
+++ b/src/block3/style.css
@@ -5,10 +5,12 @@
  * Replace them with your own styles or remove the file completely.
  */
 
-@tailwind components;
-@tailwind utilities;
+ @tailwind base;
+ @tailwind components;
+ @tailwind utilities;
 
 .wp-block-create-block-block3 {
-	background-color: #df1a5c;
-	color: #fff;
+	/* background-color: #df1a5c;
+	color: #fff; */
+	@apply bg-[#df1a5c] text-white;
 }

--- a/src/block3/tailwind.config.js
+++ b/src/block3/tailwind.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-	content: ['./src/block3/*js'],
+	content: ['./src/block1/*js', './src/block1/*css'],
 	theme: {
 		extend: {},
 	},


### PR DESCRIPTION
Greetings!

I filed an issue w/ your repo earlier. But as I continued to experiment, I noticed that tailwind was not properly integrated w/ the *.scss files...i.e. the @tailwind imports were not working, and I couldn't use the @apply directive.

Finding it unlikely that using SASS & PostCSS / Tailwind was necessary, I implemented the simplest fix.

Renamed all the *.scss files allow the @tailwind imports to work properly. It also allows use of the @apply directive, so that rather than reverting to custom CSS, you can do things like:
```
.my-class {
    @apply rounded-2xl bg-green-500 text-[#arbitrary-color-value]
}
```
**NOTE:** #arbitrary-color-value has to be an actual valid CSS color value; used as example/documentation of what the brackets mean here...

Also fixed the ./json import error issue.

Thanks again for sharing your code! 

I just started implementing custom Gutenberg blocks on a headless WordPress project, w/ SvelteKit & TailwindCSS for the frontend, and while Tailpress allows a similar end result (i.e. using Tailwind to style the blocks in the editor & frontend), having the blocks generate the actual compiled CSS seems like a great option for future projects, where perhaps Tailpress as the main theme wouldn't work.

All the best,
Morgan
😌🙏